### PR TITLE
Rework video output to use a Twig template

### DIFF
--- a/templates/partials/youtube.html.twig
+++ b/templates/partials/youtube.html.twig
@@ -1,0 +1,3 @@
+<div class="grav-youtube">
+    <iframe src="https://www.youtube.com/embed/{{- video_id -}}?vq=hd1080" frameborder="0" allowfullscreen></iframe>
+</div>


### PR DESCRIPTION
This reworks the rendered video output to use a Twig template to allow template overrides as mentioned in #3. It is also the preparation for #4.