### PR TITLE
Allow Youtube player parameters to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,24 @@ You should now have all the plugin files under
 ```
 enabled: true
 built_in_css: true
+player_parameters:
+  autoplay: 0
+  cc_load_policy: 0
+  color: red
+  controls: 1
+  disablekb: 0
+  enablejsapi: 0
+  fs: 1
+  hl: ''
+  iv_load_policy: 1
+  loop: 0
+  modestbranding: 0
+  origin: ''
+  playsinline: 0
+  rel: 1
+  showinfo: 1
+  vq: default
+privacy_enhanced_mode: false
 ```
 
 If you need to change any value, then the best process is to copy the [youtube.yaml](youtube.yaml) file into your `users/config/plugins/` folder (create it if it doesn't exist), and then modify there.  This will override the default settings.

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -47,3 +47,212 @@ form:
         0: Disabled
       validate:
         type: bool
+
+    privacy_enhanced_mode:
+      type: toggle
+      label: Privacy-enhanced mode
+      help: If enabled, YouTube won’t store information about visitors on your web page unless they play the video.
+      highlight: 0
+      default: 0
+      options:
+        1: Enabled
+        0: Disabled
+      validate:
+        type: bool
+
+    player_parameters:
+      type: section
+      title: Player parameters
+      underline: true
+      fields:
+
+        player_parameters.vq:
+          type: select
+          size: medium
+          label: Preferred video quality
+          help: Specifies the preferred video quality to display. This may be overridden by YouTube to improve playback quality based on the user's screen resolution, bandwidth etc.
+          default: 'default'
+          options:
+            default: Default
+            small: Small
+            medium: Medium
+            large: Large
+            highres: High resolution
+            hd1080: High definition (1080)
+            hd720: High definition (720)
+          validate:
+            type: string
+
+        player_parameters.autoplay:
+          type: toggle
+          label: Autoplay
+          help: Specifies whether the initial video will automatically start to play when the player loads.
+          highlight: 0
+          default: 0
+          options:
+            1: Enabled
+            0: Disabled
+          validate:
+            type: int
+
+        player_parameters.loop:
+          type: toggle
+          label: Loop
+          help: If enabled, the player will play the initial video again and again.
+          highlight: 0
+          default: 0
+          options:
+            1: Enabled
+            0: Disabled
+          validate:
+            type: int
+
+        player_parameters.showinfo:
+          type: toggle
+          label: Show information
+          help: If enabled, the player will display information like the video title and uploader before the video starts playing.
+          highlight: 1
+          default: 1
+          options:
+            1: Enabled
+            0: Disabled
+          validate:
+            type: int
+
+        player_parameters.rel:
+          type: toggle
+          label: Related videos
+          help: If enabled, the player will show related videos when playback of the initial video ends.
+          highlight: 1
+          default: 1
+          options:
+            1: Enabled
+            0: Disabled
+          validate:
+            type: int
+
+        player_parameters.modestbranding:
+          type: toggle
+          label: Modest branding
+          help: If enabled, the YouTube logo won't be displayed in the control bar. Note that a small YouTube text label will still display in the upper-right corner of a paused video when the user's mouse pointer hovers over the player.
+          highlight: 0
+          default: 0
+          options:
+            1: Enabled
+            0: Disabled
+          validate:
+            type: int
+
+        player_parameters.color:
+          type: select
+          size: medium
+          label: Color
+          help: Specifies the color that will be used in the player's video progress bar to highlight the amount of the video that the viewer has already seen. Setting this to white will disable the modest branding option.
+          default: red
+          options:
+            red: Red
+            white: White
+          validate:
+            type: string
+
+        player_parameters.cc_load_policy:
+          type: toggle
+          label: Show closed captions by default
+          help: If enabled, this causes closed captions to be shown by default, even if the user has turned captions off. The default behavior is based on user preference.
+          highlight: 0
+          default: 0
+          options:
+            1: Enabled
+            0: Disabled
+          validate:
+            type: int
+
+        player_parameters.iv_load_policy:
+          type: select
+          size: medium
+          label: Video annotations
+          help: Specifies whether video annotatins should be displayed.
+          default: 1
+          options:
+            1: Displayed by default
+            3: Hidden by default
+          validate:
+            type: int
+
+        player_parameters.controls:
+          type: toggle
+          label: Controls
+          help: Indicates whether the video player controls are displayed.
+          highlight: 1
+          default: 1
+          options:
+            1: Enabled
+            0: Disabled
+          validate:
+            type: int
+
+        player_parameters.disablekb:
+          type: toggle
+          label: Keyboard controls
+          help: If enabled, the player responds to supported keyboard controls.
+          highlight: 0
+          default: 0
+          options:
+            1: Enabled
+            0: Disabled
+          validate:
+            type: int
+
+        player_parameters.fs:
+          type: toggle
+          label: Fullscreen button
+          help: If enabled, the player displays the fullscreen button.
+          highlight: 1
+          default: 1
+          options:
+            1: Enabled
+            0: Disabled
+          validate:
+            type: int
+
+        player_parameters.hl:
+          type: text
+          label: Language
+          placeholder: 'e.g. en or en-us'
+          help: Specifies the player's interface language. This has to be an ISO 639-1 two-letter language code or a fully specified locale. The interface language is used for tooltips in the player and also affects the default caption track. Note that YouTube might select a different caption track language for a particular user based on the user's individual language preferences and the availability of caption tracks.
+          default: ''
+          validate:
+            type: string
+
+        player_parameters.enablejsapi:
+          type: toggle
+          label: JavaScript API
+          help: If enabled, the player may be controlled via IFrame or JavaScript Player API calls.
+          highlight: 0
+          default: 0
+          options:
+            1: Enabled
+            0: Disabled
+          validate:
+            type: int
+
+        player_parameters.origin:
+          type: text
+          label: Origin
+          placeholder: 'e.g. example.com'
+          help: If using the IFrame API, specify your domain name. This provides an extra security measure for the IFrame API and is only supported for IFrame embeds.
+          default: ''
+          validate:
+            type: string
+
+        player_parameters.playsinline:
+          type: toggle
+          label: iOS playback behavior
+          help: Specifies whether videos play inline or fullscreen in an HTML5 player on iOS.
+          highlight: 0
+          default: 0
+          options:
+            0: Fullscreen
+            1: Inline
+          validate:
+            type: int

--- a/classes/Twig/YoutubeTwigExtension.php
+++ b/classes/Twig/YoutubeTwigExtension.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Grav\Plugin\Youtube\Twig;
+
+use Grav\Common\GravTrait;
+
+class YoutubeTwigExtension extends \Twig_Extension
+{
+    use GravTrait;
+
+    /**
+     * Returns extension name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'YoutubeTwigExtension';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new \Twig_SimpleFunction('youtube_embed_url', [$this, 'embedUrl']),
+        ];
+    }
+
+    /**
+     * Builds YouTube video embed URL.
+     *
+     * @param  string  $video_id
+     * @param  array   $player_parameters
+     * @param  bool    $privacy_enhanced_mode
+     * @return string
+     */
+    public function embedUrl($video_id, array $player_parameters = array(), $privacy_enhanced_mode = FALSE)
+    {
+        $grav = static::getGrav();
+
+        // build base video embed URL (while respecting privacy enhanced mode setting)
+        $url = '//youtube' . ($privacy_enhanced_mode ? '-nocookie' : '') . '.com/embed/' . $video_id;
+
+        // filter player parameters to only those not matching YouTube defaults
+        $filtered_player_parameters = array();
+        foreach ($player_parameters as $key => $value) {
+            $parameter_blueprint = $grav['config']->blueprints()->get('plugins.youtube.player_parameters.' . $key);
+
+            // configured value matches YouTube default -> skip parameter
+            if (isset($parameter_blueprint['default']) && $parameter_blueprint['default'] == $value) {
+                continue;
+            }
+
+            $filtered_player_parameters[$key] = $value;
+        }
+
+        // append query string (if any)
+        if (!empty($filtered_player_parameters) && ($query_string = http_build_query($filtered_player_parameters))) {
+            $url .= '?' . $query_string;
+        }
+
+        return $url;
+    }
+}

--- a/classes/Twig/YoutubeTwigExtension.php
+++ b/classes/Twig/YoutubeTwigExtension.php
@@ -41,7 +41,7 @@ class YoutubeTwigExtension extends \Twig_Extension
         $grav = static::getGrav();
 
         // build base video embed URL (while respecting privacy enhanced mode setting)
-        $url = '//youtube' . ($privacy_enhanced_mode ? '-nocookie' : '') . '.com/embed/' . $video_id;
+        $url = '//www.youtube' . ($privacy_enhanced_mode ? '-nocookie' : '') . '.com/embed/' . $video_id;
 
         // filter player parameters to only those not matching YouTube defaults
         $filtered_player_parameters = array();

--- a/templates/partials/youtube.html.twig
+++ b/templates/partials/youtube.html.twig
@@ -1,3 +1,3 @@
 <div class="grav-youtube">
-    <iframe src="https://www.youtube.com/embed/{{- video_id -}}?vq=hd1080" frameborder="0" allowfullscreen></iframe>
+    <iframe src="{{- youtube_embed_url(video_id, player_parameters, privacy_enhanced_mode) -}}" frameborder="0" allowfullscreen></iframe>
 </div>

--- a/youtube.php
+++ b/youtube.php
@@ -63,8 +63,8 @@ class YoutubePlugin extends Plugin
         $page = $event['page'];
         /** @var Twig $twig */
         $twig = $this->grav['twig'];
-        $config = $this->mergeConfig($page);
-
+        /** @var Data $config */
+        $config = $this->mergeConfig($page, TRUE);
 
         if ($config->get('enabled')) {
             // Get raw content and substitute all formulas by a unique token

--- a/youtube.php
+++ b/youtube.php
@@ -9,10 +9,11 @@
 
 namespace Grav\Plugin;
 
-use Grav\Common\Grav;
+use Grav\Common\Data\Data;
 use Grav\Common\Plugin;
 use Grav\Common\Page\Page;
 use Grav\Common\Twig\Twig;
+use Grav\Plugin\Youtube\Twig\YoutubeTwigExtension;
 use RocketTheme\Toolbox\Event\Event;
 
 class YoutubePlugin extends Plugin
@@ -47,6 +48,7 @@ class YoutubePlugin extends Plugin
 
         $this->enable([
             'onPageContentRaw' => ['onPageContentRaw', 0],
+            'onTwigExtensions' => ['onTwigExtensions', 0],
             'onTwigSiteVariables' => ['onTwigSiteVariables', 0],
             'onTwigTemplatePaths' => ['onTwigTemplatePaths', 0],
         ]);
@@ -71,7 +73,7 @@ class YoutubePlugin extends Plugin
             $raw = $page->getRawContent();
 
             // build an anonymous function to pass to `parseLinks()`
-            $function = function ($matches) use ($twig) {
+            $function = function ($matches) use ($twig, $config) {
                 $search = $matches[0];
 
                 // double check to make sure we found a valid YouTube video ID
@@ -79,9 +81,11 @@ class YoutubePlugin extends Plugin
                     return $search;
                 }
 
-                // build the replacement embeded HTML string
+                // build the replacement embed HTML string
                 $replace = $twig->processTemplate('partials/youtube.html.twig', array(
-                  'video_id' => $matches[1],
+                    'player_parameters' => $config->get('player_parameters'),
+                    'privacy_enhanced_mode' => $config->get('privacy_enhanced_mode'),
+                    'video_id' => $matches[1],
                 ));
 
                 // do the replacement
@@ -91,6 +95,15 @@ class YoutubePlugin extends Plugin
             // set the parsed content back into as raw content
             $page->setRawContent($this->parseLinks($raw, $function, $this::YOUTUBE_REGEX));
         }
+    }
+
+    /**
+     * Add Twig Extensions.
+     */
+    public function onTwigExtensions()
+    {
+        require_once __DIR__ . '/classes/twig/YoutubeTwigExtension.php';
+        $this->grav['twig']->twig->addExtension(new YoutubeTwigExtension());
     }
 
     /**

--- a/youtube.yaml
+++ b/youtube.yaml
@@ -1,3 +1,21 @@
 enabled: true
 built_in_css: true
 add_editor_button: true
+player_parameters:
+  autoplay: 0
+  cc_load_policy: 0
+  color: red
+  controls: 1
+  disablekb: 0
+  enablejsapi: 0
+  fs: 1
+  hl: ''
+  iv_load_policy: 1
+  loop: 0
+  modestbranding: 0
+  origin: ''
+  playsinline: 0
+  rel: 1
+  showinfo: 1
+  vq: default
+privacy_enhanced_mode: false


### PR DESCRIPTION
This introduces new configuration options to set up YouTube player parameters (see also #4). It also introduces a new ```YoutubeTwigExtension```class which provides the ```youtube_embed_url()```Twig function to build YouTube video embed URLs.

The following player parameters/options are now configurable via the plugin configuration (details about each new configuration may be found in the ```blueprints.yaml```file):

* privacy_enhanced_mode
* player_parameters:
  * autoplay
  * cc_load_policy
  * color
  * controls
  * disablekb
  * enablejsapi
  * fs
  * hl
  * iv_load_policy
  * loop
  * modestbranding
  * origin
  * playsinline
  * rel
  * showinfo
  * vq

It is also still possible to override player parameters/options on a specific page, as its frontmatter configuration gets merged with the default plugin configuration.