### PR TITLE
Update iframe URLs to always use HTTPS

### DIFF
--- a/classes/Twig/YoutubeTwigExtension.php
+++ b/classes/Twig/YoutubeTwigExtension.php
@@ -41,7 +41,7 @@ class YoutubeTwigExtension extends \Twig_Extension
         $grav = static::getGrav();
 
         // build base video embed URL (while respecting privacy enhanced mode setting)
-        $url = '//www.youtube' . ($privacy_enhanced_mode ? '-nocookie' : '') . '.com/embed/' . $video_id;
+        $url = 'https://www.youtube' . ($privacy_enhanced_mode ? '-nocookie' : '') . '.com/embed/' . $video_id;
 
         // filter player parameters to only those not matching YouTube defaults
         $filtered_player_parameters = array();


### PR DESCRIPTION
Hey All,

I'm applying a content security policy to a website I'm working on that only allows iframes to be embedded from `https://www.youtube.com`. When working on a dev version of the site on my local machine, the iframe fails to load because the plugin currently uses protocol-relative URLs and I am not developing in an HTTPS environment.

Additionally, YouTube enforces a redirect from HTTP -> HTTPS, so a protocol-relative URL only adds unnecessary overhead when loading a video on a Grav site served over HTTP.

To resolve these issues, this pull request updates the plugin to always use HTTPS URLs for YouTube.


Regards,
--- Scott