### PR TITLE
Add lazy_load option

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -36,6 +36,17 @@ form:
       validate:
         type: bool
 
+    built_in_js:
+      type: toggle
+      label: Use built in JS
+      highlight: 0
+      default: 0
+      options:
+        1: Enabled
+        0: Disabled
+      validate:
+        type: bool
+
     add_editor_button:
       type: toggle
       label: Add editor button
@@ -53,6 +64,18 @@ form:
       label: Privacy-enhanced mode
       help: If enabled, YouTube won’t store information about visitors on your web page unless they play the video.
       highlight: 0
+      default: 0
+      options:
+        1: Enabled
+        0: Disabled
+      validate:
+        type: bool
+    
+    lazy_load:
+      type: toggle
+      label: Lazy load iframes
+      help: If enabled, only the preview thumbnail will be loaded. When clicked, the iframe will be loaded. Improves page load speed.
+      hightlight: 0
       default: 0
       options:
         1: Enabled

--- a/classes/Twig/YoutubeTwigExtension.php
+++ b/classes/Twig/YoutubeTwigExtension.php
@@ -24,6 +24,7 @@ class YoutubeTwigExtension extends \Twig_Extension
     {
         return [
             new \Twig_SimpleFunction('youtube_embed_url', [$this, 'embedUrl']),
+            new \Twig_SimpleFunction('youtube_thumbnail_url', [$this, 'thumbnailUrl']),
         ];
     }
 
@@ -59,6 +60,13 @@ class YoutubeTwigExtension extends \Twig_Extension
         if (!empty($filtered_player_parameters) && ($query_string = http_build_query($filtered_player_parameters))) {
             $url .= '?' . $query_string;
         }
+
+        return $url;
+    }
+
+    public function thumbnailUrl($video_id)
+    {
+        $url = 'https://i.ytimg.com/vi/' . $video_id . '/hqdefault.jpg';
 
         return $url;
     }

--- a/css/youtube.css
+++ b/css/youtube.css
@@ -16,3 +16,45 @@
     height: 100%;
     position: absolute;
 }
+
+.grav-youtube--lazyloaded {
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: cover;
+    cursor: pointer;
+}
+
+.grav-youtube--lazyloaded button {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 68px;
+    height: 48px;
+    margin-left: -34px;
+    margin-top: -24px;
+    border: none;
+    background-color: transparent;
+    padding: 0;
+    outline: 0;
+    cursor: pointer;
+}
+
+.grav-youtube--lazyloaded iframe:not([src]) {
+    display: none;
+}
+
+.grav-youtube--lazyloaded iframe[src] + button {
+    display: none;
+}
+
+.grav-youtube--lazyloaded path:first-of-type {
+    -webkit-transition: fill .1s cubic-bezier(0.0,0.0,0.2,1), fill-opacity .1s cubic-bezier(0.0,0.0,0.2,1);
+    -o-transition: fill .1s cubic-bezier(0.0,0.0,0.2,1), fill-opacity .1s cubic-bezier(0.0,0.0,0.2,1);
+    transition: fill .1s cubic-bezier(0.0,0.0,0.2,1), fill-opacity .1s cubic-bezier(0.0,0.0,0.2,1)
+}
+
+.grav-youtube--lazyloaded:hover path:first-of-type,
+.grav-youtube--lazyloaded button:focus path:first-of-type {
+    fill: #f00;
+    fill-opacity: 1;
+}

--- a/js/youtube.js
+++ b/js/youtube.js
@@ -1,0 +1,13 @@
+(function() {
+  window.addEventListener('DOMContentLoaded', function() {
+    var gravYoutubeEmbeds = document.querySelectorAll('.grav-youtube--lazyloaded');
+
+    for (var i = 0; i < gravYoutubeEmbeds.length; i++) {
+      gravYoutubeEmbeds[i].addEventListener('click', function() {
+        var iframe = this.querySelector('iframe');
+        var src = iframe.getAttribute('data-src');
+        iframe.src = src;
+      });
+    }
+  });
+})();

--- a/templates/partials/youtube.html.twig
+++ b/templates/partials/youtube.html.twig
@@ -1,3 +1,15 @@
+{% if lazy_load == true %}
+<div class="grav-youtube grav-youtube--lazyloaded" style="background-image: url('{{- youtube_thumbnail_url(video_id) -}}')">
+    <iframe data-src="{{- youtube_embed_url(video_id, player_parameters, privacy_enhanced_mode) -}}" frameborder="0" allow="autoplay" allowfullscreen></iframe>
+    <button>
+        <svg viewBox="0 0 68 48">
+            <path d="M66.52,7.74c-0.78-2.93-2.49-5.41-5.42-6.19C55.79,.13,34,0,34,0S12.21,.13,6.9,1.55 C3.97,2.33,2.27,4.81,1.48,7.74C0.06,13.05,0,24,0,24s0.06,10.95,1.48,16.26c0.78,2.93,2.49,5.41,5.42,6.19 C12.21,47.87,34,48,34,48s21.79-0.13,27.1-1.55c2.93-0.78,4.64-3.26,5.42-6.19C67.94,34.95,68,24,68,24S67.94,13.05,66.52,7.74z" fill="#212121" fill-opacity="0.8"></path>
+            <path d="M 45,24 27,14 27,34" fill="#fff"></path>
+        </svg>
+    </button>
+</div>
+{% else %}
 <div class="grav-youtube">
     <iframe src="{{- youtube_embed_url(video_id, player_parameters, privacy_enhanced_mode) -}}" frameborder="0" allowfullscreen></iframe>
 </div>
+{% endif %}

--- a/youtube.php
+++ b/youtube.php
@@ -84,8 +84,13 @@ class YoutubePlugin extends Plugin
                 $options = array(
                     'player_parameters' => $config->get('player_parameters'),
                     'privacy_enhanced_mode' => $config->get('privacy_enhanced_mode'),
+                    'lazy_load' => $config->get('lazy_load'),
                     'video_id' => $matches[1]
                 );
+
+                if($options['lazy_load'] == true) {
+                    $options['player_parameters']['autoplay'] = true;
+                }
 
                 // check if size was given
                 if (isset($matches[2]) && isset($matches[3])) {
@@ -122,6 +127,10 @@ class YoutubePlugin extends Plugin
     {
         if (!$this->isAdmin() && $this->config->get('plugins.youtube.built_in_css')) {
             $this->grav['assets']->add('plugin://youtube/css/youtube.css');
+        }
+
+        if (!$this->isAdmin() && $this->config->get('plugins.youtube.built_in_js')) {
+            $this->grav['assets']->add('plugin://youtube/js/youtube.js');
         }
 
         if ($this->isAdmin() && $this->config->get('plugins.youtube.add_editor_button')) {

--- a/youtube.yaml
+++ b/youtube.yaml
@@ -1,5 +1,6 @@
 enabled: true
 built_in_css: true
+built_in_js: false
 add_editor_button: true
 player_parameters:
   autoplay: 0
@@ -19,3 +20,4 @@ player_parameters:
   showinfo: 1
   vq: default
 privacy_enhanced_mode: false
+lazy_load: false


### PR DESCRIPTION
With `lazy_load` enabled, the YouTube preview thumbnail and play button are displayed. When clicked, the iframe gets loaded and the video automatically starts playing.

Requires both `lazy_load` and `built_in_js` to be enabled.

Closes #26.