### PR TITLE
Fix padding to remove black bars at top and bottom

### DIFF
--- a/css/youtube.css
+++ b/css/youtube.css
@@ -1,7 +1,6 @@
 .grav-youtube {
     height: 0;
-    padding-top: 25px;
-    padding-bottom: 56.34%;
+    padding-bottom: 56.25%;
     margin-bottom: 10px;
     position: relative;
     overflow: hidden;


### PR DESCRIPTION
Two small changes:
- Change padding to 56.25% rather than 56.34%, which is the correct ratio for 16:9 (HD etc.) video.
- Removed 25px padding-top, not sure what this was doing but it was also creating black bars.