### PR TITLE
Loop parameter fix for a single video

### DIFF
--- a/classes/Twig/YoutubeTwigExtension.php
+++ b/classes/Twig/YoutubeTwigExtension.php
@@ -53,6 +53,11 @@ class YoutubeTwigExtension extends \Twig_Extension
                 continue;
             }
 
+            //YouTube loop fix for HTML5 player
+            if ($key == 'loop' && $value == 1) {
+                $filtered_player_parameters['playlist'] = $video_id;
+            }
+            
             $filtered_player_parameters[$key] = $value;
         }
 


### PR DESCRIPTION
In order to play a single video in a loop, a playlist parameter with the same videoID has to be passed as described in #24

This is official solution described in YouTube Docs: https://developers.google.com/youtube/player_parameters#loop