### PR TITLE
Fix #37 shortcode ignoring plugin configuration

### DIFF
--- a/classes/Twig/YoutubeTwigExtension.php
+++ b/classes/Twig/YoutubeTwigExtension.php
@@ -36,12 +36,17 @@ class YoutubeTwigExtension extends \Twig_Extension
      * @param  bool    $privacy_enhanced_mode
      * @return string
      */
-    public function embedUrl($video_id, array $player_parameters = array(), $privacy_enhanced_mode = FALSE)
+    public function embedUrl($video_id, array $player_parameters = array(), $privacy_enhanced_mode = FALSE, $lazy_load = FALSE)
     {
         $grav = Grav::instance();
 
         // build base video embed URL (while respecting privacy enhanced mode setting)
         $url = 'https://www.youtube' . ($privacy_enhanced_mode ? '-nocookie' : '') . '.com/embed/' . $video_id;
+
+        // Set the video to autoplay if lazy_load is enabled
+        if($lazy_load == true) {
+            $player_parameters['autoplay'] = true;
+        }
 
         // filter player parameters to only those not matching YouTube defaults
         $filtered_player_parameters = array();

--- a/shortcodes/YoutubeShortcode.php
+++ b/shortcodes/YoutubeShortcode.php
@@ -11,10 +11,12 @@ class YoutubeShortcode extends Shortcode
     {
         $this->shortcode->getHandlers()->add('youtube', function(ShortcodeInterface $sc) {
 
+            // Get Plugin configuration
+            $pluginConfig = $this->config->get('plugins.youtube');
+
             // Get shortcode content and parameters
             $url = $sc->getContent();
             $params = $sc->getParameters();
-            $privacy_mode = $sc->getParameter('privacy_enhanced_mode');
 
             if ($url) {
                 preg_match($this::YOUTUBE_REGEX, $url, $matches);
@@ -29,10 +31,11 @@ class YoutubeShortcode extends Shortcode
                 $twig = $this->grav['twig'];
 
                 $options = array(
-                    'player_parameters' => $params,
-                    'privacy_enhanced_mode' => $privacy_mode,
+                    'player_parameters' => array_merge($pluginConfig['player_parameters'],$params),
+                    'privacy_enhanced_mode' => $sc->getParameter('privacy_enhanced_mode',$pluginConfig['privacy_enhanced_mode']),
                     'video_id' => $matches[1],
                     'class' => $sc->getParameter('class'),
+                    'lazy_load' => $sc->getParameter('lazy_load',$pluginConfig['lazy_load']),
                 );
 
                 // check if size was given

--- a/templates/partials/youtube.html.twig
+++ b/templates/partials/youtube.html.twig
@@ -1,7 +1,7 @@
 <div class="grav-youtube-wrapper {{ class }}">
 {% if lazy_load == true %}
   <div class="grav-youtube grav-youtube--lazyloaded" style="background-image: url('{{- youtube_thumbnail_url(video_id) -}}')">
-      <iframe data-src="{{- youtube_embed_url(video_id, player_parameters, privacy_enhanced_mode) -}}" frameborder="0" allow="autoplay" allowfullscreen></iframe>
+      <iframe data-src="{{- youtube_embed_url(video_id, player_parameters, privacy_enhanced_mode, lazy_load) -}}" frameborder="0" allow="autoplay" allowfullscreen></iframe>
       <button>
           <svg viewBox="0 0 68 48">
               <path d="M66.52,7.74c-0.78-2.93-2.49-5.41-5.42-6.19C55.79,.13,34,0,34,0S12.21,.13,6.9,1.55 C3.97,2.33,2.27,4.81,1.48,7.74C0.06,13.05,0,24,0,24s0.06,10.95,1.48,16.26c0.78,2.93,2.49,5.41,5.42,6.19 C12.21,47.87,34,48,34,48s21.79-0.13,27.1-1.55c2.93-0.78,4.64-3.26,5.42-6.19C67.94,34.95,68,24,68,24S67.94,13.05,66.52,7.74z" fill="#212121" fill-opacity="0.8"></path>

--- a/youtube.php
+++ b/youtube.php
@@ -89,10 +89,7 @@ class YoutubePlugin extends Plugin
                     'video_id' => $matches[1]
                 );
 
-                if($options['lazy_load'] == true) {
-                    $options['player_parameters']['autoplay'] = true;
-                }
-
+                
                 // check if size was given
                 if (isset($matches[2]) && isset($matches[3])) {
                     $options['video_size'] = true;


### PR DESCRIPTION
Fixes bug #37 

Fixes:
- plugin configuration not considered when processing shortcode
- lazy_load parameter ignored when processing shortcode

Also:
- moved setting autoload=1 if lazy_load=true from the main youtube.php into the twig handler, to avoid duplicating it for the shortcode processer as well.

Please test!