### PR TITLE
Removed 'showinfo' player parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ player_parameters:
   origin: ''
   playsinline: 0
   rel: 1
-  showinfo: 1
   vq: default
 privacy_enhanced_mode: false
 ```

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -132,18 +132,6 @@ form:
           validate:
             type: int
 
-        player_parameters.showinfo:
-          type: toggle
-          label: Show information
-          help: If enabled, the player will display information like the video title and uploader before the video starts playing.
-          highlight: 1
-          default: 1
-          options:
-            1: Enabled
-            0: Disabled
-          validate:
-            type: int
-
         player_parameters.rel:
           type: toggle
           label: Related videos

--- a/youtube.yaml
+++ b/youtube.yaml
@@ -17,7 +17,6 @@ player_parameters:
   origin: ''
   playsinline: 0
   rel: 1
-  showinfo: 1
   vq: default
 privacy_enhanced_mode: false
 lazy_load: false


### PR DESCRIPTION
This has been deprecated by youtube and no longer has any functionality.

https://developers.google.com/youtube/player_parameters#august-23,-2018