### PR TITLE
Create a shortcode option for custom thumbnail

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,11 @@ As of version `3.0` you can now use an alternative _shortcode_ syntax that suppo
 [youtube color=white autoplay=1]https://www.youtube.com/watch?v=BK8guP9ov2U[/youtube]
 ```
 
+Using the shortcode syntax it is also possible to set a custom thumbnail picture when using lazy_load. 
+
+```
+[youtube lazy_load=true thumbnail="name of media.jpg"]https://www.youtube.com/watch?v=BK8guP9ov2U[/youtube]
+```
+
+
 [grav]: http://github.com/getgrav/grav

--- a/shortcodes/YoutubeShortcode.php
+++ b/shortcodes/YoutubeShortcode.php
@@ -35,7 +35,7 @@ class YoutubeShortcode extends Shortcode
 
                     if (isset($page_media[$custom_thumbnail])) {
                         // Get the url of the thumbnail.
-                        // No resizing takes (the best size is not known) place so there is a potential performance problem here if the user specifies a very large image!
+                        // No resizing takes place (the most appropriate size is not known) so there is a potential performance problem here if the user specifies a very large image!
                         $custom_thumbnail_url = $page_media[$custom_thumbnail]->url();
                     }
                 }

--- a/shortcodes/YoutubeShortcode.php
+++ b/shortcodes/YoutubeShortcode.php
@@ -27,6 +27,18 @@ class YoutubeShortcode extends Shortcode
                     return $search;
                 }
 
+
+                // If there is a custom thumbnail, get the url
+                $custom_thumbnail_url ='';                
+                if($custom_thumbnail = $sc->getParameter('thumbnail')) {
+                    $page_media = $this->grav['page']->media();
+
+                    if (isset($page_media[$custom_thumbnail])) {
+                        $custom_thumbnail_url = $page_media[$custom_thumbnail]->url();
+                    }
+                }
+
+
                 /** @var Twig $twig */
                 $twig = $this->grav['twig'];
 
@@ -36,6 +48,7 @@ class YoutubeShortcode extends Shortcode
                     'video_id' => $matches[1],
                     'class' => $sc->getParameter('class'),
                     'lazy_load' => $sc->getParameter('lazy_load',$pluginConfig['lazy_load']),
+                    'thumbnail' => $custom_thumbnail_url,
                 );
 
                 // check if size was given

--- a/shortcodes/YoutubeShortcode.php
+++ b/shortcodes/YoutubeShortcode.php
@@ -34,6 +34,8 @@ class YoutubeShortcode extends Shortcode
                     $page_media = $this->grav['page']->media();
 
                     if (isset($page_media[$custom_thumbnail])) {
+                        // Get the url of the thumbnail.
+                        // No resizing takes (the best size is not known) place so there is a potential performance problem here if the user specifies a very large image!
                         $custom_thumbnail_url = $page_media[$custom_thumbnail]->url();
                     }
                 }

--- a/templates/partials/youtube.html.twig
+++ b/templates/partials/youtube.html.twig
@@ -1,7 +1,7 @@
 <div class="grav-youtube-wrapper {{ class }}">
 {% if lazy_load == true %}
   <div class="grav-youtube grav-youtube--lazyloaded">
-      <img src="{{- youtube_thumbnail_url(video_id) -}}" loading="lazy"/>
+      <img src="{{- thumbnail ?: youtube_thumbnail_url(video_id)|e -}}" loading="lazy"/>
       <iframe data-src="{{- youtube_embed_url(video_id, player_parameters, privacy_enhanced_mode, lazy_load) -}}" frameborder="0" allow="autoplay" allowfullscreen></iframe>
       <button>
           <svg viewBox="0 0 68 48">


### PR DESCRIPTION
Add a method so that when using the shortcode syntax it is possible to set a custom thumbnail picture when using lazy_load. 

```
[youtube lazy_load=true thumbnail="name of media.jpg"]https://www.youtube.com/watch?v=BK8guP9ov2U[/youtube]
```

Very useful for 
- higher quality thumbnails
- changing the thumbnail if it's the youtube video is not under your control