### PR TITLE
Use privacy enabled embeds by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ player_parameters:
   playsinline: 0
   rel: 1
   vq: default
-privacy_enhanced_mode: false
+privacy_enhanced_mode: true
 ```
 
 If you need to change any value, then the best process is to copy the [youtube.yaml](youtube.yaml) file into your `users/config/plugins/` folder (create it if it doesn't exist), and then modify there.  This will override the default settings.

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -66,7 +66,7 @@ form:
       label: Privacy-enhanced mode
       help: If enabled, YouTube won’t store information about visitors on your web page unless they play the video.
       highlight: 0
-      default: 0
+      default: 1
       options:
         1: Enabled
         0: Disabled

--- a/youtube.yaml
+++ b/youtube.yaml
@@ -18,5 +18,5 @@ player_parameters:
   playsinline: 0
   rel: 1
   vq: default
-privacy_enhanced_mode: false
+privacy_enhanced_mode: true
 lazy_load: false


### PR DESCRIPTION
I propose to enable enhanced privacy embeds by default. IMHO, in this day and age software needs to be secure and privacy enabled by default.